### PR TITLE
Upgrade plugin com.github.johnrengelman.shadow to 7.1.2

### DIFF
--- a/jsettlers.main.swing/build.gradle
+++ b/jsettlers.main.swing/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'com.github.johnrengelman.shadow' version '5.2.0'
+	id 'com.github.johnrengelman.shadow' version '7.1.2'
 	id 'application'
 }
 


### PR DESCRIPTION
Upgrade plugin com.github.johnrengelman.shadow to 7.1.2 in order to avoid "property 'mainClass' is final and cannot be changed any further." of task runShadow

This occurs with Gradle 7.x. A good explanation why can be found in https://stackoverflow.com/questions/63862653/property-mainclass-is-final-and-cannot-be-changed-any-further.