### PR TITLE
Ensure the tools are run from the project directory when inside an IDE that supports Gradle

### DIFF
--- a/jsettlers.tools/build.gradle
+++ b/jsettlers.tools/build.gradle
@@ -22,3 +22,5 @@ jar {
         attributes 'Class-Path' : 'JSettlers.jar'
     }
 }
+
+tasks.run.workingDir = rootProject.projectDir


### PR DESCRIPTION
On my change to .gitignore in https://github.com/paulwedeck/settlers-remake/pull/49 you commented this change would not be necessary if the tools were run from the correct directory. After checking, the behaviour of running from the project root is IDE-specific (see https://stackoverflow.com/questions/60798844/customize-working-directory-run-gradle-run-task-project-structure-for-web-appl).

Therefore let's define it in the build script so the choice of IDE is irrelevant.

Note: This only gets evident when running the tools from the custom-graphics branch as they create a bunch of directories and files directly after startup.