### PR TITLE
Remove deprecation that gradle labels as...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ allprojects {
     repositories {
         mavenCentral()
         google()
-        jcenter()
         // fallback for vbps
         //maven { url "https://raw.github.com/laenger/maven-releases/master/releases" }
         maven { url "https://maven.google.com" }


### PR DESCRIPTION
The RepositoryHandler.jcenter() method has been deprecated. This is scheduled to be removed in Gradle 8.0. JFrog announced JCenter's sunset in February 2021. Use mavenCentral() instead. Consult the upgrading guide for further information: https://docs.gradle.org/7.4.2/userguide/upgrading_version_6.html#jcenter_deprecation