### PR TITLE
Add linux data files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,6 +159,12 @@ task releaseJSettlers(type: Zip) {
         from tasks.getByPath(':jsettlers.mapcreator:jar')
         from tasks.getByPath(':jsettlers.tools:jar')
 
+        from project.getRootProject().file('jsettlers.mapcreator/src/main/resources/jsettlers/mapcreator/main/window/icon.png')
+
+        into('dist') {
+            from project.getRootProject().file('dist')
+        }
+
         into('maps') {
             from project.getRootProject().file('maps/release')
         }

--- a/dist/linux/com.github.paulwedeck.settlers-remake.desktop
+++ b/dist/linux/com.github.paulwedeck.settlers-remake.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Name=JSettlers
+Exec=jsettlers
+Icon=com.github.paulwedeck.settlers-remake
+Terminal=false
+Type=Application
+Categories=Game;StrategyGame;Java;
+Comment=A Remake of "The Settlers III" for Windows, Linux, Mac and Android
+Comment[de]=Ein "Die Siedler III" remake für Windows, Linux, Mac und Android
+Keywords=Settler;RTS;Realtime Strategy;Economic Simulation Game;History;Warfare;Romans; 

--- a/dist/linux/com.github.paulwedeck.settlers-remake.mapcreator.desktop
+++ b/dist/linux/com.github.paulwedeck.settlers-remake.mapcreator.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Name=JSettlers Mapcreator
+Exec=jsettlers-mapcreator
+Icon=com.github.paulwedeck.settlers-remake
+Terminal=false
+Type=Application
+Categories=Game;StrategyGame;Java;
+Comment=Mapcreator for JSettlers
+Comment[de]=Karteneditor für JSettlers
+Keywords=Settler;map editor;RTS;Realtime Strategy;Economic Simulation Game;History;Warfare;Romans; 

--- a/dist/linux/com.github.paulwedeck.settlers-remake.metainfo.xml
+++ b/dist/linux/com.github.paulwedeck.settlers-remake.metainfo.xml
@@ -1,0 +1,98 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="desktop">
+  <!--Created with jdAppdataEdit 5.1-->
+  <id>com.github.paulwedeck.settlers-remake</id>
+  <name>JSettlers</name>
+  <summary>A Remake of "The Settlers III" for Windows, Linux, Mac and Android</summary>
+  <summary xml:lang="de">Ein "Die Siedler III" remake für Windows, Linux, Mac und Android</summary>
+  <developer_name>paulwedeck</developer_name>
+  <launchable type="desktop-id">com.github.paulwedeck.settlers-remake.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <description>
+    <p>JSettlers is an open source remake of the game The Settlers III by BlueByte. The main goal of the game is to build an economy and fight other players.</p>
+    <p xml:lang="de">JSettlers ist ein Open-Source-Remake des Spiels "Die Siedler III" von BlueByte. Das Hauptziel des Spiels ist es, eine Wirtschaft aufzubauen und andere Spieler zu bekämpfen.</p>
+    <p>JSettlers needs the graphics files from an original Settlers III installation. The demo version work as well but only contains Roman and Amazon graphics files.</p>
+    <p xml:lang="de">JSettlers benötigt die Grafikdateien aus einer originalen "Siedler III" Installation. Die Demoversion funktioniert ebenfalls, enthält aber nur Römer und AmazonenGrafikdateien.</p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Multiplayer menu</caption>
+      <caption xml:lang="de">Mehrspielermenü</caption>
+      <image type="source">https://github.com/paulwedeck/settlers-remake/blob/0b4a2424f4b511777c70b0ed3971261cf2af9e53/docs/screenshots/mp_menu.png?raw=true</image>
+    </screenshot>
+    <screenshot>
+      <caption>Buildings</caption>
+      <caption xml:lang="de">Gebäude</caption>
+      <image type="source">https://github.com/paulwedeck/settlers-remake/blob/0b4a2424f4b511777c70b0ed3971261cf2af9e53/docs/screenshots/new_buildings.png?raw=true</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="v0.6.0.2-alpha" date="2022-08-07" type="development">
+      <url>https://github.com/paulwedeck/settlers-remake/releases/tag/v0.6.0.2-alpha</url>
+    </release>
+    <release version="v0.6.0.1-alpha" date="2022-05-20" type="development">
+      <url>https://github.com/paulwedeck/settlers-remake/releases/tag/v0.6.0.1-alpha</url>
+    </release>
+    <release version="v0.6-alpha" date="2022-03-27" type="stable">
+      <url>https://github.com/paulwedeck/settlers-remake/releases/tag/v0.6-alpha</url>
+    </release>
+    <release version="v0.5.4.2-alpha" date="2022-03-09" type="development">
+      <url>https://github.com/paulwedeck/settlers-remake/releases/tag/v0.5.4.2-alpha</url>
+    </release>
+    <release version="v0.5.4-alpha" date="2022-03-06" type="stable">
+      <url>https://github.com/paulwedeck/settlers-remake/releases/tag/v0.5.4-alpha</url>
+    </release>
+    <release version="v0.5.3-alpha4" date="2022-02-05" type="development">
+      <url>https://github.com/paulwedeck/settlers-remake/releases/tag/v0.5.3-alpha4</url>
+    </release>
+    <release version="v0.5.3-alpha3" date="2022-02-02" type="development">
+      <url>https://github.com/paulwedeck/settlers-remake/releases/tag/v0.5.3-alpha3</url>
+    </release>
+    <release version="v0.5.3-alpha2" date="2021-11-11" type="development">
+      <url>https://github.com/paulwedeck/settlers-remake/releases/tag/v0.5.3-alpha2</url>
+    </release>
+    <release version="v0.5.3-alpha" date="2021-10-24" type="stable">
+      <url>https://github.com/paulwedeck/settlers-remake/releases/tag/v0.5.3-alpha</url>
+    </release>
+    <release version="v0.5.2-alpha" date="2021-10-17" type="stable">
+      <url>https://github.com/paulwedeck/settlers-remake/releases/tag/v0.5.2-alpha</url>
+    </release>
+    <release version="v0.5.1-alpha2" date="2021-08-17" type="development">
+      <url>https://github.com/paulwedeck/settlers-remake/releases/tag/v0.5.1-alpha2</url>
+    </release>
+    <release version="v0.5.1-alpha" date="2021-06-27" type="stable">
+      <url>https://github.com/paulwedeck/settlers-remake/releases/tag/v0.5.1-alpha</url>
+    </release>
+    <release version="v0.5.0-alpha" date="2021-06-06" type="stable">
+      <url>https://github.com/paulwedeck/settlers-remake/releases/tag/v0.5.0-alpha</url>
+    </release>
+  </releases>
+  <url type="homepage">https://github.com/paulwedeck/settlers-remake</url>
+  <url type="bugtracker">https://github.com/paulwedeck/settlers-remake/issues</url>
+  <categories>
+    <category>Game</category>
+    <category>StrategyGame</category>
+    <category>Java</category>
+  </categories>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+  </recommends>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-fantasy">moderate</content_attribute>
+  </content_rating>
+  <provides>
+    <binary>jsettlers</binary>
+    <binary>jsettlers-mapcreator</binary>
+  </provides>
+  <keywords>
+    <keyword>Settler</keyword>
+    <keyword>RTS</keyword>
+    <keyword>Realtime Strategy</keyword>
+    <keyword>Economic Simulation Game</keyword>
+    <keyword>History</keyword>
+    <keyword>Warfare</keyword>
+    <keyword>Romans</keyword>
+  </keywords>
+</component>


### PR DESCRIPTION
This PR adds some linux data files needed for Flatpak, The .desktop files are taken from the AUR package. The metainfo.xml file holds all information for the software centers and the Flathub website. I also translated the metainfo into German. This files can also be used outside Flatpak. Please make sure to add new releases to the metainfo before releasing.