### PR TITLE
Fix NPE on map load when a tile has an unrecognised landscape id

### DIFF
--- a/jsettlers.logic/src/main/java/jsettlers/logic/map/loading/original/OriginalMapFileContent.java
+++ b/jsettlers.logic/src/main/java/jsettlers/logic/map/loading/original/OriginalMapFileContent.java
@@ -343,7 +343,11 @@ public class OriginalMapFileContent implements IMutableMapData {
 		BitSet notBlockedSet = new BitSet(dataCount);
 
 		for (int pos = 0; pos < dataCount; pos++) {
-			notBlockedSet.set(pos, !landscapeType[pos].isBlocking);
+			// Some tiles may have an unrecognised landscape id and end up null
+			// (OriginalLandscape.getTypeByInt returned null). Treat null as not
+			// blocking, matching the GRASS fallback in getLandscape().
+			ELandscapeType type = landscapeType[pos];
+			notBlockedSet.set(pos, type == null || !type.isBlocking);
 		}
 
 		PartitionCalculatorAlgorithm partitionCalculator = new PartitionCalculatorAlgorithm(0, 0, widthHeight, widthHeight, notBlockedSet,


### PR DESCRIPTION
OriginalMapFileContent.calculateBlockedPartitions() dereferences landscapeType[pos] without checking for null while computing the 'not blocked' bitset for the partition algorithm.

Some original Settlers 3 maps contain tile bytes that OriginalLandscape.getTypeByInt() does not recognise, returning null. The result is a hard crash on map open:

  Cannot read field "isBlocking" because
  "this.landscapeType[pos]" is null

Treat null as non-blocking, mirroring the existing GRASS fallback in getLandscape(int, int).